### PR TITLE
Update http URIs to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Below are some basic examples. There's more detailed documentation [here](https:
 
 ### Word/phrase search (provided by official Jisho API)
 
-This returns the same results as the official [Jisho.org](https://jisho.org/) API. See the discussion of that [here](http://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api).
+This returns the same results as the official [Jisho.org](https://jisho.org/) API. See the discussion of that [here](https://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api).
 
 ```js
 const JishoApi = require('unofficial-jisho-api');
@@ -72,10 +72,10 @@ Onyomi: ["ゴ"]
 Onyomi example: {"example":"語","reading":"ゴ","meaning":"language, word"}
 Radical: {"symbol":"言","forms":["訁"],"meaning":"speech"}
 Parts: ["口","五","言"]
-Stroke order diagram: http://classic.jisho.org/static/images/stroke_diagrams/35486_frames.png
-Stroke order SVG: http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08a9e.svg
+Stroke order diagram: https://classic.jisho.org/static/images/stroke_diagrams/35486_frames.png
+Stroke order SVG: https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08a9e.svg
 Stroke order GIF: https://raw.githubusercontent.com/mistval/kotoba/master/resources/images/kanjianimations/08a9e_anim.gif
-Jisho Uri: http://jisho.org/search/%E8%AA%9E%23kanji
+Jisho Uri: https://jisho.org/search/%E8%AA%9E%23kanji
 ```
 
 ### Example search
@@ -102,7 +102,7 @@ jisho.searchForExamples('日').then(result => {
 This outputs the following:
 
 ```
-Jisho Uri: http://jisho.org/search/%E6%97%A5%23sentences
+Jisho Uri: https://jisho.org/search/%E6%97%A5%23sentences
 
 日本人ならそんなことはけっしてしないでしょう。
 にほんじんならそんなことはけっしてしないでしょう。

--- a/README.md
+++ b/README.md
@@ -245,6 +245,6 @@ request(SEARCH_URI, (error, response, body) => {
 
 ## About
 
-Permission to scrape granted by Jisho's admin Kimtaro: http://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api
+Permission to scrape granted by Jisho's admin Kimtaro: https://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api
 
 For bugs or requested additional data, feel free to open an issue on the Github repo.

--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
 <h2>Basic usage</h2>
 <p>Below are some basic examples. There's more detailed documentation <a href="https://mistval.github.io/unofficial-jisho-api/">here</a>.</p>
 <h3>Word/phrase search (provided by official Jisho API)</h3>
-<p>This returns the same results as the official <a href="https://jisho.org/">Jisho.org</a> API. See the discussion of that <a href="http://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api">here</a>.</p>
+<p>This returns the same results as the official <a href="https://jisho.org/">Jisho.org</a> API. See the discussion of that <a href="https://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api">here</a>.</p>
 <pre class="prettyprint source lang-js"><code>const jishoApi = require('unofficial-jisho-api');
 const jisho = new jishoApi();
 
@@ -251,7 +251,7 @@ request(SEARCH_URI, (error, response, body) => {
 <h2>Version history</h2>
 <p><strong>v2.0.0</strong> replaces <a href="https://www.npmjs.com/package/request">request</a> with <a href="https://www.npmjs.com/package/axios">axios</a>, as request is now <a href="https://github.com/request/request/issues/3142">in maintenance</a> (and was bloated anyway). This significantly reduces install size. The <code>requestOptions</code> parameters that most of this APIs functions used to take has been deprecated and removed.</p>
 <h2>About</h2>
-<p>Permission to scrape granted by Jisho's admin Kimtaro: http://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api</p>
+<p>Permission to scrape granted by Jisho's admin Kimtaro: https://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api</p>
 <p>For bugs or requested additional data, feel free to open an issue on the Github repo.</p></article>
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,10 +106,10 @@ Onyomi: [&quot;ゴ&quot;]
 Onyomi example: {&quot;example&quot;:&quot;語&quot;,&quot;reading&quot;:&quot;ゴ&quot;,&quot;meaning&quot;:&quot;language, word&quot;}
 Radical: {&quot;symbol&quot;:&quot;言&quot;,&quot;forms&quot;:[&quot;訁&quot;],&quot;meaning&quot;:&quot;speech&quot;}
 Parts: [&quot;口&quot;,&quot;五&quot;,&quot;言&quot;]
-Stroke order diagram: http://classic.jisho.org/static/images/stroke_diagrams/35486_frames.png
-Stroke order SVG: http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08a9e.svg
+Stroke order diagram: https://classic.jisho.org/static/images/stroke_diagrams/35486_frames.png
+Stroke order SVG: https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08a9e.svg
 Stroke order GIF: https://raw.githubusercontent.com/mistval/kotoba/master/resources/images/kanjianimations/08a9e_anim.gif
-Jisho Uri: http://jisho.org/search/%E8%AA%9E%23kanji
+Jisho Uri: https://jisho.org/search/%E8%AA%9E%23kanji
 </code></pre>
 <h3>Example search</h3>
 <pre class="prettyprint source lang-js"><code>const jishoApi = require('unofficial-jisho-api');
@@ -130,7 +130,7 @@ jisho.searchForExamples('日').then(result => {
 });
 </code></pre>
 <p>This outputs the following:</p>
-<pre class="prettyprint source"><code>Jisho Uri: http://jisho.org/search/%E6%97%A5%23sentences
+<pre class="prettyprint source"><code>Jisho Uri: https://jisho.org/search/%E6%97%A5%23sentences
 
 日本人ならそんなことはけっしてしないでしょう。
 にほんじんならそんなことはけっしてしないでしょう。

--- a/docs/index.js.html
+++ b/docs/index.js.html
@@ -45,7 +45,7 @@
  * This module encapsulates the official Jisho.org API
  * and also provides kanji and example search features that scrape Jisho.org.
  * Permission to scrape granted by Jisho's admin Kimtaro:
- *     http://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api
+ *     https://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api
  */
 
 const axios = require('axios').create({ timeout: 10000 });

--- a/docs/index.js.html
+++ b/docs/index.js.html
@@ -53,9 +53,9 @@ const cheerio = require('cheerio');
 const escapeStringRegexp = require('escape-string-regexp');
 const { XmlEntities } = require('html-entities');
 
-const JISHO_API = 'http://jisho.org/api/v1/search/words';
-const SCRAPE_BASE_URI = 'http://jisho.org/search/';
-const STROKE_ORDER_DIAGRAM_BASE_URI = 'http://classic.jisho.org/static/images/stroke_diagrams/';
+const JISHO_API = 'https://jisho.org/api/v1/search/words';
+const SCRAPE_BASE_URI = 'https://jisho.org/search/';
+const STROKE_ORDER_DIAGRAM_BASE_URI = 'https://classic.jisho.org/static/images/stroke_diagrams/';
 
 const htmlEntities = new XmlEntities();
 
@@ -226,7 +226,7 @@ function getParts(pageHtml) {
 function getSvgUri(pageHtml) {
   const svgRegex = /\/\/.*?.cloudfront.net\/.*?.svg/;
   const regexResult = svgRegex.exec(pageHtml);
-  return regexResult ? `http:${regexResult[0]}` : undefined;
+  return regexResult ? `https:${regexResult[0]}` : undefined;
 }
 
 function getGifUri(kanji) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * This module encapsulates the official Jisho.org API
  * and also provides kanji and example search features that scrape Jisho.org.
  * Permission to scrape granted by Jisho's admin Kimtaro:
- *     http://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api
+ *     https://jisho.org/forum/54fefc1f6e73340b1f160000-is-there-any-kind-of-search-api
  */
 
 const axios = require('axios').create({ timeout: 10000 });
@@ -10,9 +10,9 @@ const cheerio = require('cheerio');
 const escapeStringRegexp = require('escape-string-regexp');
 const { XmlEntities } = require('html-entities');
 
-const JISHO_API = 'http://jisho.org/api/v1/search/words';
-const SCRAPE_BASE_URI = 'http://jisho.org/search/';
-const STROKE_ORDER_DIAGRAM_BASE_URI = 'http://classic.jisho.org/static/images/stroke_diagrams/';
+const JISHO_API = 'https://jisho.org/api/v1/search/words';
+const SCRAPE_BASE_URI = 'https://jisho.org/search/';
+const STROKE_ORDER_DIAGRAM_BASE_URI = 'https://classic.jisho.org/static/images/stroke_diagrams/';
 
 const htmlEntities = new XmlEntities();
 
@@ -183,7 +183,7 @@ function getParts(pageHtml) {
 function getSvgUri(pageHtml) {
   const svgRegex = /\/\/.*?.cloudfront.net\/.*?.svg/;
   const regexResult = svgRegex.exec(pageHtml);
-  return regexResult ? `http:${regexResult[0]}` : undefined;
+  return regexResult ? `https:${regexResult[0]}` : undefined;
 }
 
 function getGifUri(kanji) {

--- a/test/example_test_cases/0.json
+++ b/test/example_test_cases/0.json
@@ -1065,7 +1065,7 @@
         ]
       }
     ],
-    "uri": "http://jisho.org/search/%E8%BB%8A%23sentences",
+    "uri": "https://jisho.org/search/%E8%BB%8A%23sentences",
     "phrase": "車"
   }
 }

--- a/test/example_test_cases/1.json
+++ b/test/example_test_cases/1.json
@@ -885,7 +885,7 @@
         ]
       }
     ],
-    "uri": "http://jisho.org/search/%E6%97%A5%E6%9C%AC%E4%BA%BA%23sentences",
+    "uri": "https://jisho.org/search/%E6%97%A5%E6%9C%AC%E4%BA%BA%23sentences",
     "phrase": "日本人"
   }
 }

--- a/test/example_test_cases/2.json
+++ b/test/example_test_cases/2.json
@@ -4,7 +4,7 @@
     "query": "彼＊叩く",
     "found": false,
     "results": [],
-    "uri": "http://jisho.org/search/%E5%BD%BC%EF%BC%8A%E5%8F%A9%E3%81%8F%23sentences",
+    "uri": "https://jisho.org/search/%E5%BD%BC%EF%BC%8A%E5%8F%A9%E3%81%8F%23sentences",
     "phrase": "彼＊叩く"
   }
 }

--- a/test/example_test_cases/3.json
+++ b/test/example_test_cases/3.json
@@ -1209,7 +1209,7 @@
         ]
       }
     ],
-    "uri": "http://jisho.org/search/%E7%9A%86%23sentences",
+    "uri": "https://jisho.org/search/%E7%9A%86%23sentences",
     "phrase": "皆"
   }
 }

--- a/test/example_test_cases/4.json
+++ b/test/example_test_cases/4.json
@@ -4,7 +4,7 @@
     "query": "ネガティブ",
     "found": false,
     "results": [],
-    "uri": "http://jisho.org/search/%E3%83%8D%E3%82%AC%E3%83%86%E3%82%A3%E3%83%96%23sentences",
+    "uri": "https://jisho.org/search/%E3%83%8D%E3%82%AC%E3%83%86%E3%82%A3%E3%83%96%23sentences",
     "phrase": "ネガティブ"
   }
 }

--- a/test/example_test_cases/5.json
+++ b/test/example_test_cases/5.json
@@ -4,7 +4,7 @@
     "query": "grlgmregmneriireg",
     "found": false,
     "results": [],
-    "uri": "http://jisho.org/search/grlgmregmneriireg%23sentences",
+    "uri": "https://jisho.org/search/grlgmregmneriireg%23sentences",
     "phrase": "grlgmregmneriireg"
   }
 }

--- a/test/kanji_test_cases/0.json
+++ b/test/kanji_test_cases/0.json
@@ -60,9 +60,9 @@
     "parts": [
       "車"
     ],
-    "strokeOrderDiagramUri": "http://classic.jisho.org/static/images/stroke_diagrams/36554_frames.png",
-    "strokeOrderSvgUri": "http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08eca.svg",
+    "strokeOrderDiagramUri": "https://classic.jisho.org/static/images/stroke_diagrams/36554_frames.png",
+    "strokeOrderSvgUri": "https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08eca.svg",
     "strokeOrderGifUri": "https://raw.githubusercontent.com/mistval/kanji_images/master/gifs/8eca.gif",
-    "uri": "http://jisho.org/search/%E8%BB%8A%23kanji"
+    "uri": "https://jisho.org/search/%E8%BB%8A%23kanji"
   }
 }

--- a/test/kanji_test_cases/1.json
+++ b/test/kanji_test_cases/1.json
@@ -119,9 +119,9 @@
       "宀",
       "豕"
     ],
-    "strokeOrderDiagramUri": "http://classic.jisho.org/static/images/stroke_diagrams/23478_frames.png",
-    "strokeOrderSvgUri": "http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/05bb6.svg",
+    "strokeOrderDiagramUri": "https://classic.jisho.org/static/images/stroke_diagrams/23478_frames.png",
+    "strokeOrderSvgUri": "https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/05bb6.svg",
     "strokeOrderGifUri": "https://raw.githubusercontent.com/mistval/kanji_images/master/gifs/5bb6.gif",
-    "uri": "http://jisho.org/search/%E5%AE%B6%23kanji"
+    "uri": "https://jisho.org/search/%E5%AE%B6%23kanji"
   }
 }

--- a/test/kanji_test_cases/2.json
+++ b/test/kanji_test_cases/2.json
@@ -91,9 +91,9 @@
       "木",
       "白"
     ],
-    "strokeOrderDiagramUri": "http://classic.jisho.org/static/images/stroke_diagrams/27005_frames.png",
-    "strokeOrderSvgUri": "http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/0697d.svg",
+    "strokeOrderDiagramUri": "https://classic.jisho.org/static/images/stroke_diagrams/27005_frames.png",
+    "strokeOrderSvgUri": "https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/0697d.svg",
     "strokeOrderGifUri": "https://raw.githubusercontent.com/mistval/kanji_images/master/gifs/697d.gif",
-    "uri": "http://jisho.org/search/%E6%A5%BD%23kanji"
+    "uri": "https://jisho.org/search/%E6%A5%BD%23kanji"
   }
 }

--- a/test/kanji_test_cases/4.json
+++ b/test/kanji_test_cases/4.json
@@ -44,9 +44,9 @@
       "貝",
       "辛"
     ],
-    "strokeOrderDiagramUri": "http://classic.jisho.org/static/images/stroke_diagrams/36100_frames.png",
-    "strokeOrderSvgUri": "http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08d04.svg",
+    "strokeOrderDiagramUri": "https://classic.jisho.org/static/images/stroke_diagrams/36100_frames.png",
+    "strokeOrderSvgUri": "https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/08d04.svg",
     "strokeOrderGifUri": "https://raw.githubusercontent.com/mistval/kanji_images/master/gifs/8d04.gif",
-    "uri": "http://jisho.org/search/%E8%B4%84%23kanji"
+    "uri": "https://jisho.org/search/%E8%B4%84%23kanji"
   }
 }

--- a/test/kanji_test_cases/7.json
+++ b/test/kanji_test_cases/7.json
@@ -70,9 +70,9 @@
     "parts": [
       "水"
     ],
-    "strokeOrderDiagramUri": "http://classic.jisho.org/static/images/stroke_diagrams/27700_frames.png",
-    "strokeOrderSvgUri": "http://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/06c34.svg",
+    "strokeOrderDiagramUri": "https://classic.jisho.org/static/images/stroke_diagrams/27700_frames.png",
+    "strokeOrderSvgUri": "https://d1w6u4xc3l95km.cloudfront.net/kanji-2015-03/06c34.svg",
     "strokeOrderGifUri": "https://raw.githubusercontent.com/mistval/kanji_images/master/gifs/6c34.gif",
-    "uri": "http://jisho.org/search/%E6%B0%B4%23kanji"
+    "uri": "https://jisho.org/search/%E6%B0%B4%23kanji"
   }
 }


### PR DESCRIPTION
The strokeOrderGifUri in a kanji query was the only URI that used https.
So in order for the URIs to be consistent and secure, everything's been updated to https.