### PR TITLE
Fix PhrasePageScrapeResult typedef

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,10 +68,15 @@ export interface PhaseScrapeMeaning {
   sentences: PhraseScrapeSentence[];
 }
 
+export interface PhraseScrapeJapaneseWord {
+  kanji: string;
+  kana: string;
+}
+
 export interface ScrapeParseResult extends QueryResult {
   tags: string[];
   meanings: PhaseScrapeMeaning[];
-  otherForms: string[];
+  otherForms: PhraseScrapeJapaneseWord[];
   notes: string[];
 }
 

--- a/index.js
+++ b/index.js
@@ -456,12 +456,18 @@ function parsePhrasePageData(pageHtml, query) {
  * @property {Array.<string>} tags Tags associated with this meaning.
  */
 
+/** @typedef {Object} PhraseScrapeJapaneseWord
+ * @property {string} kanji The japanese word, written in kanji if available
+ * @property {string} [kana] The corresponding kana spelling of the whole word, if kanji is present
+ */
+
 /**
  * @typedef {Object} PhrasePageScrapeResult
  * @property {boolean} found True if a result was found.
  * @property {string} query The term that you searched for.
  * @property {string} [uri] The URI that these results were scraped from, if a result was found.
- * @property {Array.<string>} [otherForms] Other forms of the search term, if a result was found.
+ * @property {Array.<PhraseScrapeJapaneseWord>} [otherForms] Other forms of the search term, if a
+ *   result was found.
  * @property {Array.<PhraseScrapeMeaning>} [meanings] Information about the meanings associated
  *   with result.
  * @property {Array.<string>} [tags] Tags associated with this search result.


### PR DESCRIPTION
There has been added a new interface to correct the otherForms property of a phrase scrape result.

I've noticed that the interface is quite similar to the JishoJapaneseWord from the API. There is a possibility to merge them together to a single interface JapaneseWord, but as it would probably break someones code and bump the project version to 3.0.0, I'll just leave it as a note.