### PR TITLE
Add missing types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,11 @@ export interface JishoSenseLink {
   url: string;
 }
 
+export interface JishoWordSource {
+  language: string;
+  word: string;
+}
+
 export interface JishoWordSense {
   english_definitions: string[];
   parts_of_speech: string[];
@@ -103,9 +108,9 @@ export interface JishoWordSense {
   tags: string[];
   see_also: string[];
   antonyms: string[];
-  source: any[];
+  source: string[];
   info: string[];
-  restrictions: any[];
+  restrictions: string[];
 }
 
 export interface JishoAttribution {

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ export interface JishoWordSense {
   tags: string[];
   see_also: string[];
   antonyms: string[];
-  source: string[];
+  source: JishoWordSource[];
   info: string[];
   restrictions: string[];
 }


### PR DESCRIPTION
These were some missing types of the native API.

The restriction list is used for describing which "versions of the word" (some words have multiple kanji) can be used to express the selected sense of the word

The source list contains information about which language(s) the word originated from.

I found them by searching through `*a`, `*i`, `*u`, `*e`, `*o`, `*n`, and filtering out the ones where the lists were populated. Turns out both are quite rare.